### PR TITLE
Updated enron_importer Dependencies for up to date usage

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 # Authors ordered by first contribution.
 Diego Pino <dpino@igalia.com>
+Dustin Saunders <dustin.saunders@sofiac.us>

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
 CHANGELOG
 
+2015-11-10: Updated enron-importer with dependency and API updates 
+
 2012-08-01: Initial release

--- a/enron-importer/pom.xml
+++ b/enron-importer/pom.xml
@@ -18,34 +18,42 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.7</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-    	<groupId>org.apache.hbase</groupId>
-    	<artifactId>hbase</artifactId>
-    	<version>0.90.5</version>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-client</artifactId>
+      <version>1.1.2</version>
     </dependency>
     <dependency>
-    	<groupId>org.apache.commons</groupId>
-    	<artifactId>commons-io</artifactId>
-    	<version>1.3.2</version>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-common</artifactId>
+      <version>1.1.2</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.4</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.6</version>
     </dependency>
   </dependencies>
-
   <build>
       <plugins>
           <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-compiler-plugin</artifactId>
-              <version>2.3.2</version>
+              <version>3.3</version>
               <configuration>
-                  <source>1.5</source>
-                  <target>1.5</target>
+                  <source>1.6</source>
+                  <target>1.6</target>
               </configuration>
           </plugin>
       </plugins>
   </build>
-
 
 </project>

--- a/enron-importer/src/main/java/com/igalia/enron_importer/Main.java
+++ b/enron-importer/src/main/java/com/igalia/enron_importer/Main.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.ZooKeeperConnectionException;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
-import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -53,11 +53,11 @@ public class Main {
 
         public static HBaseHelper create() throws MasterNotRunningException, ZooKeeperConnectionException , IOException {
             HBaseHelper result = new HBaseHelper();
-            result.hbase = new HBaseAdmin(conf);
+            result.hbase = result.connection.getAdmin();
             return result;
         }
 
-        private HBaseAdmin hbase;
+        private Admin hbase;
         private Connection connection;
         static {
             conf.set("hbase.master","localhost:60000");
@@ -88,8 +88,8 @@ public class Main {
         }
 
         public void dropTable(String tableName) throws IOException {
-            hbase.disableTable(tableName);
-            hbase.deleteTable(tableName);
+            hbase.disableTable(TableName.valueOf(tableName));
+            hbase.deleteTable(TableName.valueOf(tableName));
         }
 
         public void insert(Table table, String rowKey, List<String> values)
@@ -104,7 +104,7 @@ public class Main {
         }
 
         public boolean tableExists(String tableName) throws IOException {
-            return hbase.tableExists(tableName);
+            return hbase.tableExists(TableName.valueOf(tableName));
         }
 
         public void closeAll(Table table) {


### PR DESCRIPTION
I successfully updated the project with the following dependency versions:

org.apache.hadoop.hbase: 0.90.5 -> 
org.apache.hadoop.hbase.common: 1.1.2
org.apache.hadoop.hbase.client: 1.1.2

org.apache.commons-io: 1.3.2 ->
commons-io: 2.4
commons-lang: 2.6

junit: 4.7 -> 4.12

org.apache.maven.plugins.maven-compiler-plugin: 2.3.2 -> 3.3

java: 1.5 -> 1.6 (Changed in the compiler-plugin settings. I believe this plugin can also be deleted from the pom).

I also updated the codebase based on API changes of the hbase library. This included using the Connection interface to get a table instance to use instead of passing around the HTable directly. I corrected the code so that it was the least impactful that it could be to the rest of the codebase.

Please let me know if you have any questions, concerns, or comments.
